### PR TITLE
Fix BaseManager.__reduce__ method

### DIFF
--- a/py2.6/multiprocess/managers.py
+++ b/py2.6/multiprocess/managers.py
@@ -457,10 +457,6 @@ class BaseManager(object):
         self._serializer = serializer
         self._Listener, self._Client = listener_client[serializer]
 
-    def __reduce__(self):
-        return type(self).from_address, \
-               (self._address, self._authkey, self._serializer)
-
     def get_server(self):
         '''
         Return server object with serve_forever() method and address attribute

--- a/py2.7/multiprocess/managers.py
+++ b/py2.7/multiprocess/managers.py
@@ -483,9 +483,6 @@ class BaseManager(object):
         self._serializer = serializer
         self._Listener, self._Client = listener_client[serializer]
 
-    def __reduce__(self):
-        return type(self), (self._address, self._authkey, self._serializer)
-
     def get_server(self):
         '''
         Return server object with serve_forever() method and address attribute

--- a/py2.7/multiprocess/managers.py
+++ b/py2.7/multiprocess/managers.py
@@ -484,8 +484,7 @@ class BaseManager(object):
         self._Listener, self._Client = listener_client[serializer]
 
     def __reduce__(self):
-        return type(self).from_address, \
-               (self._address, self._authkey, self._serializer)
+        return type(self), (self._address, self._authkey, self._serializer)
 
     def get_server(self):
         '''

--- a/py3.1/multiprocess/managers.py
+++ b/py3.1/multiprocess/managers.py
@@ -486,10 +486,6 @@ class BaseManager(object):
         self._serializer = serializer
         self._Listener, self._Client = listener_client[serializer]
 
-    def __reduce__(self):
-        return type(self).from_address, \
-               (self._address, self._authkey, self._serializer)
-
     def get_server(self):
         '''
         Return server object with serve_forever() method and address attribute

--- a/py3.2/multiprocess/managers.py
+++ b/py3.2/multiprocess/managers.py
@@ -486,10 +486,6 @@ class BaseManager(object):
         self._serializer = serializer
         self._Listener, self._Client = listener_client[serializer]
 
-    def __reduce__(self):
-        return type(self).from_address, \
-               (self._address, self._authkey, self._serializer)
-
     def get_server(self):
         '''
         Return server object with serve_forever() method and address attribute


### PR DESCRIPTION
The __reduce__ method was trying to access some non existent attribute 'from_address'.